### PR TITLE
Cancel running workflows for updated pull requests

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,6 +9,13 @@ on:
   release:
     types: [published]
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build source distribution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - main
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: "Check for changes"


### PR DESCRIPTION
This PR updates the Actions workflow settings so that previous workflow runs will be canceled when PR branch is updated.

These settings were taken from [here](https://core.trac.wordpress.org/changeset/50930/trunk/.github/workflows/coding-standards.yml).