### PR TITLE
Remove NumFOCUS from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: numfocus
+github:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             - 'tests/**/*.c'
             - 'aehmc/**/*.h'
             - 'tests/**/*.h'
-            - '.github/**/*.yml'
+            - '.github/workflows/*.yml'
             - 'setup.cfg'
             - 'requirements.txt'
             - '.coveragerc'


### PR DESCRIPTION
This PR removes the GitHub sponsor setting for NumFOCUS.