### PR TITLE
Generate a scalar momentum for scalar inverse mass matrices

### DIFF
--- a/aehmc/integrators.py
+++ b/aehmc/integrators.py
@@ -63,9 +63,14 @@ def velocity_verlet(
         kinetic_grad = aesara.grad(kinetic_energy_fn(new_momentum), new_momentum)
         new_position = position + a2 * step_size * kinetic_grad
 
-        new_potential_energy = potential_fn(new_position)
-        new_potential_energy_grad = aesara.grad(new_potential_energy, new_position)
-        new_momentum = new_momentum - b1 * step_size * new_potential_energy_grad
+        pos = position.clone()
+        npe = potential_fn(pos)
+        npeg = aesara.grad(npe, pos)
+        nm = new_momentum - b1 * step_size * npeg
+
+        new_momentum = aesara.clone_replace(nm, {pos: new_position})
+        new_potential_energy = aesara.clone_replace(npe, {pos: new_position})
+        new_potential_energy_grad = aesara.clone_replace(npeg, {pos: new_position})
 
         return (
             new_position,

--- a/aehmc/metrics.py
+++ b/aehmc/metrics.py
@@ -47,12 +47,20 @@ def gaussian_metric(
             Information. Springer, Berlin, Heidelberg, 2013.
 
     """
-    shape = shape_tuple(inverse_mass_matrix)[0]
 
-    if inverse_mass_matrix.ndim == 1:
+    # When the argument to `logprob_fn` is a scalar, so must be the inverse mass matrix
+    # and the momentum.
+    try:
+        shape = shape_tuple(inverse_mass_matrix)[0]
+        ndim = inverse_mass_matrix.ndim
+    except (AttributeError, IndexError):
+        shape = None
+        ndim = 1
+
+    if ndim == 1:
         mass_matrix_sqrt = aet.sqrt(aet.reciprocal(inverse_mass_matrix))
         dot, matmul = lambda x, y: x * y, lambda x, y: x * y
-    elif inverse_mass_matrix.ndim == 2:
+    elif ndim == 2:
         tril_inv = slinalg.cholesky(inverse_mass_matrix)
         identity = aet.eye(shape)
         mass_matrix_sqrt = slinalg.solve_lower_triangular(tril_inv, identity)


### PR DESCRIPTION
The `momentum_generator` function returned by `gaussian_metric` currently returns a `vector` when `inverse_mass_matrix` is a scalar. This behavior is problematic when the logprob returned by `aeppl` takes a scalar as an input (see #26).

In this PR we make `momentum_generator` return a scalar instead, and we add a unit test. While the code "works", I think it would be cleaner if:

- `shape_tuple` returned an empty tuple for a scalar input (currently raises an exception);
- `aesara` implemented the equivalent of `np.ndim` which returns 0 for scalar.