### PR TITLE
Raise exception on shape error in CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,6 @@ def pytest_sessionstart(session):
     os.environ["AESARA_FLAGS"] = ",".join(
         [
             os.environ.setdefault("AESARA_FLAGS", ""),
-            "floatX=float64,warn__ignore_bug_before=all",
+            "floatX=float64,on_opt_error=raise,on_shape_error=raise",
         ]
     )


### PR DESCRIPTION
This PR is to track the warning found in #29. We set the `on_shape_error` config variable to `raise` in the CI; the tests will fail until the underlying issue is fixed.