### PR TITLE
Acceptance probability in NUTS

### DIFF
--- a/aehmc/nuts.py
+++ b/aehmc/nuts.py
@@ -116,7 +116,7 @@ def kernel(
         # Diagnostics
         is_turning = result[-1][-1]
         is_diverging = result[-2][-1]
-        num_steps = result[-3][-1]
+        num_doublings = result[-3][-1]
         acceptance_probability = result[-4][-1]
 
         return (
@@ -124,7 +124,7 @@ def kernel(
             potential_energy_new,
             potential_energy_grad_new,
             acceptance_probability,
-            num_steps,
+            num_doublings,
             is_turning,
             is_diverging,
         )

--- a/aehmc/trajectory.py
+++ b/aehmc/trajectory.py
@@ -387,7 +387,7 @@ def multiplicative_expansion(
             # Compute the pseudo-acceptance probability for the NUTS algorithm.
             # It can be understood as the average acceptance probability MC would give to
             # the states explored during the final expansion.
-            acceptance_probability = new_proposal[3] / subtrajectory_length
+            acceptance_probability = at.exp(new_proposal[3]) / subtrajectory_length
 
             # Update the proposal.
             # If the termination criterion is reached in the subtree or if a

--- a/aehmc/trajectory.py
+++ b/aehmc/trajectory.py
@@ -148,6 +148,7 @@ def dynamic_integration(
             momentum_sum_ckpts,
             idx_min,
             idx_max,
+            trajectory_length,
         ):
             state = (
                 q_last,
@@ -190,7 +191,7 @@ def dynamic_integration(
                 *new_state,
                 new_momentum_sum,
                 *new_termination_state,
-                step + 1,
+                trajectory_length + 1,
                 is_diverging,
                 has_terminated,
             ), until(do_stop_integrating)
@@ -217,7 +218,7 @@ def dynamic_integration(
                 *state,
                 momentum_sum,
                 *termination_state,
-                None,
+                at.as_tensor(1, dtype="int32"),
                 None,
                 None,
             ),
@@ -233,7 +234,7 @@ def dynamic_integration(
         new_state = (traj[7][-1], traj[8][-1], traj[9][-1], traj[10][-1])
         subtree_momentum_sum = traj[11][-1]
         new_termination_state = (traj[12][-1], traj[13][-1], traj[14][-1], traj[15][-1])
-        num_steps = traj[-3][-1]
+        trajectory_length = traj[-3][-1]  # defined as the number of steps taken
         is_diverging = traj[-2][-1] | is_diverging
         has_terminated = traj[-1][-1]
 
@@ -242,7 +243,7 @@ def dynamic_integration(
             new_state,
             subtree_momentum_sum,
             new_termination_state,
-            num_steps,
+            trajectory_length,
             is_diverging,
             has_terminated,
         ), updates

--- a/aehmc/trajectory.py
+++ b/aehmc/trajectory.py
@@ -190,7 +190,7 @@ def dynamic_integration(
                 *new_state,
                 new_momentum_sum,
                 *new_termination_state,
-                step,
+                step + 1,
                 is_diverging,
                 has_terminated,
             ), until(do_stop_integrating)
@@ -233,7 +233,7 @@ def dynamic_integration(
         new_state = (traj[7][-1], traj[8][-1], traj[9][-1], traj[10][-1])
         subtree_momentum_sum = traj[11][-1]
         new_termination_state = (traj[12][-1], traj[13][-1], traj[14][-1], traj[15][-1])
-        num_steps = 1 + traj[-3][-1]
+        num_steps = traj[-3][-1]
         is_diverging = traj[-2][-1] | is_diverging
         has_terminated = traj[-1][-1]
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -95,4 +95,4 @@ def test_welford_scalar(do_compute_covariance):
         state = update(sample, *state)
 
     cov = final(state[1], state[2]).eval()
-    assert pytest.approx(cov.squeeze(), 55.0 / 6.0)
+    assert pytest.approx(cov.squeeze()) == 55.0 / 6.0


### PR DESCRIPTION
Work on on #48 showed that the computed values of the `acceptance_probability` for the NUTS algorithms were sometimes completely wrong. This PR fixes the way the value is computed and also makes the computation more numerically stable.