### PR TITLE
Make the HMC & NUTS kernels return `scan` updates

### DIFF
--- a/aehmc/nuts.py
+++ b/aehmc/nuts.py
@@ -98,7 +98,7 @@ def kernel(
             at.as_tensor(0.0, dtype="float64"),
             at.as_tensor(-np.inf, dtype="float64"),
         )
-        result, _ = expand(
+        result, updates = expand(
             initial_proposal,
             initial_state,
             initial_state,
@@ -127,6 +127,6 @@ def kernel(
             num_doublings,
             is_turning,
             is_diverging,
-        )
+        ), updates
 
     return step

--- a/aehmc/trajectory.py
+++ b/aehmc/trajectory.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple
+from typing import Callable, Dict, Tuple
 
 import aesara
 import aesara.tensor as at
@@ -38,14 +38,14 @@ def static_integration(
 
     def integrate(
         q_init, p_init, energy_init, energy_grad_init, step_size
-    ) -> IntegratorStateType:
+    ) -> Tuple[IntegratorStateType, Dict]:
         def one_step(q, p, potential_energy, potential_energy_grad):
             new_state = integrator(
                 q, p, potential_energy, potential_energy_grad, step_size
             )
             return new_state
 
-        [q, p, energy, energy_grad], _ = aesara.scan(
+        [q, p, energy, energy_grad], updates = aesara.scan(
             fn=one_step,
             outputs_info=[
                 {"initial": q_init},
@@ -56,7 +56,7 @@ def static_integration(
             n_steps=num_integration_steps,
         )
 
-        return q[-1], p[-1], energy[-1], energy_grad[-1]
+        return (q[-1], p[-1], energy[-1], energy_grad[-1]), updates
 
     return integrate
 

--- a/tests/test_step_size.py
+++ b/tests/test_step_size.py
@@ -48,9 +48,11 @@ def test_dual_averaging_adaptation(init):
     step, logstepsize_avg, gradient_avg = init(at.as_tensor(0.0, dtype="floatX"))
 
     def one_step(q, logprob, logprob_grad, step, x_t, x_avg, gradient_avg):
-        *state, p_accept = kernel(q, logprob, logprob_grad, at.exp(x_t))
+        (*state, p_accept), inner_updates = kernel(
+            q, logprob, logprob_grad, at.exp(x_t)
+        )
         da_state = update(p_accept, step, x_t, x_avg, gradient_avg)
-        return (*state, *da_state, p_accept)
+        return (*state, *da_state, p_accept), inner_updates
 
     states, updates = aesara.scan(
         fn=one_step,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -58,8 +58,8 @@ def test_static_integration(example):
     p = at.vector("p")
     energy = potential(q)
     energy_grad = aesara.grad(energy, q)
-    final_state = integrator(q, p, energy, energy_grad, step_size)
-    integrate_fn = aesara.function((q, p), final_state)
+    final_state, updates = integrator(q, p, energy, energy_grad, step_size)
+    integrate_fn = aesara.function((q, p), final_state, updates=updates)
 
     q_final, p_final, *_ = integrate_fn(q_init, p_init)
 


### PR DESCRIPTION
Since #55 the inner scans do not use `default_update`s but instead return the inner updates following scan's inner function semantics. In this PR we make kernel return inner updates as well.