### PR TITLE
Fix test seeding

### DIFF
--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -164,7 +164,7 @@ def test_nuts_mcse():
 
     trajectory_generator = aesara.function((y_vv,), trajectory[0], updates=updates)
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=32098)
     posterior_samples = trajectory_generator(rng.standard_normal(2))[-1000:]
 
     error_prob = compute_error_probability(posterior_samples, loc)
@@ -213,7 +213,7 @@ def test_hmc_mcse():
 
     trajectory_generator = aesara.function((y_vv,), trajectory[0], updates=updates)
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=23982)
     posterior_samples = trajectory_generator(rng.standard_normal(2))[-1000:]
 
     error_prob = compute_error_probability(posterior_samples, loc)

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -158,8 +158,8 @@ def test_nuts_mcse():
             None,
             None,
         ],
-        non_sequences=1.0,
-        n_steps=3000,
+        non_sequences=0.5,
+        n_steps=2000,
     )
 
     trajectory_generator = aesara.function((y_vv,), trajectory[0], updates=updates)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -78,7 +78,7 @@ def test_dynamic_integration(case):
     srng = RandomStream(seed=59)
 
     def potential_fn(x):
-        return -at.sum(logprob(at.random.normal(0.0, 1.0), x))
+        return -at.sum(logprob(srng.normal(0.0, 1.0), x))
 
     step_size, should_diverge, should_turn = case
 


### PR DESCRIPTION
This PR fixes the seeds for some tests that were previously unseeded.  It also reverts the test settings for `test_nuts_mcse`, since the larger step size does not appear to be passing the ESS threshold (and it's not clear that it should, given the covariance).