### PR TITLE
Fix RaveledParamsMap dtypes

### DIFF
--- a/aehmc/utils.py
+++ b/aehmc/utils.py
@@ -28,6 +28,8 @@ class RaveledParamsMap:
         self.ref_shapes = [at.shape(p) for p in self.ref_params]
         self.ref_shapes = simplify_shapes(self.ref_shapes)
 
+        self.ref_dtypes = [p.dtype for p in self.ref_params]
+
         ref_shapes_ancestors = set(ancestors(self.ref_shapes))
         uninferred_shape_params = [
             p for p in self.ref_params if (p in ref_shapes_ancestors)
@@ -59,11 +61,12 @@ class RaveledParamsMap:
     ) -> Dict[TensorVariable, TensorVariable]:
         """Unravel a concatenated set of raveled parameters."""
         return {
-            k: v.reshape(s)
-            for k, v, s in zip(
+            k: v.reshape(s).astype(t)
+            for k, v, s, t in zip(
                 self.ref_params,
                 [raveled_params[slc] for slc in self.vec_slices],
                 self.ref_shapes,
+                self.ref_dtypes,
             )
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,6 +58,28 @@ def test_RaveledParamsMap():
     assert np.array_equal(kappa_part.eval(new_test_point), exp_kappa_part)
 
 
+def test_RaveledParamsMap_dtype():
+    tau_rv = at.random.normal(0, 1, name="tau")
+    tau_vv = tau_rv.clone()
+    tau_vv.name = "t"
+
+    lambda_rv = at.random.binomial(10, 0.5, name="lmbda")
+    lambda_vv = lambda_rv.clone()
+    lambda_vv.name = "l"
+
+    params_map = {tau_rv: tau_vv, lambda_rv: lambda_vv}
+    rp_map = RaveledParamsMap(params_map.keys())
+
+    q = rp_map.ravel_params((tau_vv, lambda_vv))
+    unraveled_params = rp_map.unravel_params(q)
+
+    tau_part = unraveled_params[tau_rv]
+    lambda_part = unraveled_params[lambda_rv]
+
+    assert tau_part.dtype == tau_rv.dtype
+    assert lambda_part.dtype == lambda_rv.dtype
+
+
 def test_RaveledParamsMap_bad_infer_shape():
     bad_normal_op = copy(at.random.normal)
 


### PR DESCRIPTION
The dtype of parameters can change as they get successively raveled and unraveled. This is problematic when sampling from the posterior distribution of a model whose observation distribution is discrete. In this PR we add a property to RaveledParamsMap that keeps track of dtypes.

