### PR TITLE
Refactor the kernel and adaptation API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,16 +30,14 @@ Example
 
     # Build the transition kernel
     srng = RandomStream(seed=0)
-    kernel = nuts.new_kernel(
-        srng,
-        logprob_fn,
-        inverse_mass_matrix=at.as_tensor(1.0),
-    )
+    kernel = nuts.kernel(srng, logprob_fn)
 
     # Compile a function that updates the chain
     y_vv = Y_rv.clone()
     initial_state = nuts.new_state(y_vv, logprob_fn)
 
+    step_size = at.as_tensor(1e-2)
+    inverse_mass_matrix=at.as_tensor(1.0)
     (
         next_state,
         potential_energy,
@@ -48,7 +46,7 @@ Example
         num_doublings,
         is_turning,
         is_diverging,
-    ), updates = kernel(*initial_state, 1e-2)
+    ), updates = kernel(*initial_state, step_size, inverse_mass_matrix)
 
     next_step_fn = aesara.function([y_vv], next_state, updates=updates)
 

--- a/aehmc/window_adaptation.py
+++ b/aehmc/window_adaptation.py
@@ -139,7 +139,9 @@ def window_adaptation(
 
         step_size = at.exp(da_state[1])
         kernel = kernel_factory(inverse_mass_matrix)
-        (*chain_state, p_accept, _, _, _), updates = kernel(*chain_state, step_size)
+        (*chain_state, p_accept, _, _, _), updates = kernel(
+            *chain_state, step_size, inverse_mass_matrix
+        )
 
         warmup_state = where_warmup_state(
             at.eq(stage, 0),

--- a/examples/LinearRegression.ipynb
+++ b/examples/LinearRegression.ipynb
@@ -221,7 +221,11 @@
    "source": [
     "srng = RandomStream(seed=0)\n",
     "inverse_mass_matrix = at.as_tensor(np.array([1., 1.]))\n",
+<<<<<<< HEAD
     "kernel = hmc.new_kernel(srng, aeppl_logprob, inverse_mass_matrix, NUM_INTEGRATION_STEPS)"
+=======
+    "kernel = hmc.kernel(srng, aeppl_logprob)"
+>>>>>>> db5bf5b (Pass parameters as input to NUTS and HMC kernels)
    ]
   },
   {
@@ -243,7 +247,7 @@
     "potential_energy = -aeppl_logprob(q)\n",
     "potential_energy_grad = aesara.grad(potential_energy, wrt=q)\n",
     "\n",
-    "next_step = kernel(q, potential_energy, potential_energy_grad, STEP_SIZE)\n",
+    "next_step = kernel(q, potential_energy, potential_energy_grad, STEP_SIZE, inverse_mass_matrix, NUM_INTEGRATION_STEPS)\n",
     "kernel_fn = aesara.function((q,), next_step)"
    ]
   },
@@ -325,7 +329,7 @@
     "        None,\n",
     "        None,\n",
     "    ],\n",
-    "    non_sequences=step_size,\n",
+    "    non_sequences=(step_size, inverse_mass_matrix, num_integration_steps),\n",
     "    n_steps=num_samples,\n",
     ")\n",
     "trajectory_generator = aesara.function(\n",
@@ -564,7 +568,11 @@
     "inverse_mass_matrix = at.vector(\"inverse_mass_matrix\")\n",
     "\n",
     "srng = RandomStream(seed=0)\n",
+<<<<<<< HEAD
     "kernel = nuts.new_kernel(srng, aeppl_logprob, inverse_mass_matrix)\n",
+=======
+    "kernel = nuts.kernel(srng, aeppl_logprob)\n",
+>>>>>>> db5bf5b (Pass parameters as input to NUTS and HMC kernels)
     "\n",
     "num_samples = at.scalar('num_samples', dtype='int32')\n",
     "trajectory, updates = aesara.scan(\n",
@@ -578,7 +586,7 @@
     "        None,\n",
     "        None,\n",
     "    ],\n",
-    "    non_sequences=step_size,\n",
+    "    non_sequences=(step_size, inverse_mass_matrix),\n",
     "    n_steps=num_samples,\n",
     ")\n",
     "trajectory_generator = aesara.function(\n",

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -20,14 +20,12 @@ def test_warmup_scalar():
         logprob = joint_logprob({Y_rv: y})
         return logprob
 
-    def kernel_factory(inverse_mass_matrix: TensorVariable):
-        return nuts.new_kernel(srng, logprob_fn)
-
     y_vv = Y_rv.clone()
+    kernel = nuts.new_kernel(srng, logprob_fn)
     initial_state = nuts.new_state(y_vv, logprob_fn)
 
     state, (step_size, inverse_mass_matrix), updates = window_adaptation.run(
-        kernel_factory, initial_state, num_steps=1000
+        kernel, initial_state, num_steps=1000
     )
 
     # Compile the warmup and execute to get a value for the step size and the
@@ -42,6 +40,7 @@ def test_warmup_scalar():
 
     assert final_state[0] != 3.0  # the chain has moved
     assert np.ndim(step_size) == 0  # scalar step size
+    assert step_size != 1.0  # step size changed
     assert step_size > 0.1 and step_size < 2  # stable range for the step size
     assert np.ndim(inverse_mass_matrix) == 0  # scalar mass matrix
     assert inverse_mass_matrix == pytest.approx(4, rel=1.0)
@@ -61,14 +60,12 @@ def test_warmup_vector():
         logprob = joint_logprob({Y_rv: y})
         return logprob
 
-    def kernel_factory(inverse_mass_matrix: TensorVariable):
-        return nuts.new_kernel(srng, logprob_fn)
-
     y_vv = Y_rv.clone()
+    kernel = nuts.new_kernel(srng, logprob_fn)
     initial_state = nuts.new_state(y_vv, logprob_fn)
 
     state, (step_size, inverse_mass_matrix), updates = window_adaptation.run(
-        kernel_factory, initial_state, num_steps=1000
+        kernel, initial_state, num_steps=1000
     )
 
     # Compile the warmup and execute to get a value for the step size and the

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -21,11 +21,7 @@ def test_warmup_scalar():
         return logprob
 
     def kernel_factory(inverse_mass_matrix: TensorVariable):
-        return nuts.new_kernel(
-            srng,
-            logprob_fn,
-            inverse_mass_matrix,
-        )
+        return nuts.new_kernel(srng, logprob_fn)
 
     y_vv = Y_rv.clone()
     initial_state = nuts.new_state(y_vv, logprob_fn)
@@ -66,11 +62,7 @@ def test_warmup_vector():
         return logprob
 
     def kernel_factory(inverse_mass_matrix: TensorVariable):
-        return nuts.new_kernel(
-            srng,
-            logprob_fn,
-            inverse_mass_matrix,
-        )
+        return nuts.new_kernel(srng, logprob_fn)
 
     y_vv = Y_rv.clone()
     initial_state = nuts.new_state(y_vv, logprob_fn)
@@ -118,12 +110,7 @@ def test_univariate_hmc(step_size, diverges):
         logprob = joint_logprob({Y_rv: y})
         return logprob
 
-    kernel = hmc.new_kernel(
-        srng,
-        logprob_fn,
-        inverse_mass_matrix,
-        num_integration_steps,
-    )
+    kernel = hmc.new_kernel(srng, logprob_fn)
 
     y_vv = Y_rv.clone()
     initial_state = hmc.new_state(y_vv, logprob_fn)
@@ -137,7 +124,7 @@ def test_univariate_hmc(step_size, diverges):
             None,
             None,
         ],
-        non_sequences=step_size,
+        non_sequences=(step_size, inverse_mass_matrix, num_integration_steps),
         n_steps=2_000,
     )
 
@@ -208,9 +195,10 @@ def test_hmc_mcse():
     srng = at.random.RandomStream(seed=1)
     (loc, scale, rho), Y_rv, logprob_fn = multivariate_normal_model(srng)
 
+    step_size = 1.0
     L = 30
     inverse_mass_matrix = at.as_tensor(scale)
-    kernel = hmc.new_kernel(srng, logprob_fn, inverse_mass_matrix, L)
+    kernel = hmc.new_kernel(srng, logprob_fn)
 
     y_vv = Y_rv.clone()
     initial_state = hmc.new_state(y_vv, logprob_fn)
@@ -224,7 +212,7 @@ def test_hmc_mcse():
             None,
             None,
         ],
-        non_sequences=1.0,
+        non_sequences=(step_size, inverse_mass_matrix, L),
         n_steps=3000,
     )
 
@@ -278,8 +266,9 @@ def test_nuts_mcse():
     srng = at.random.RandomStream(seed=1)
     (loc, scale, rho), Y_rv, logprob_fn = multivariate_normal_model(srng)
 
+    step_size = at.as_tensor(1.0)
     inverse_mass_matrix = at.as_tensor(scale)
-    kernel = nuts.new_kernel(srng, logprob_fn, inverse_mass_matrix)
+    kernel = nuts.new_kernel(srng, logprob_fn)
 
     y_vv = Y_rv.clone()
     initial_state = nuts.new_state(y_vv, logprob_fn)
@@ -295,7 +284,7 @@ def test_nuts_mcse():
             None,
             None,
         ],
-        non_sequences=1.0,
+        non_sequences=(step_size, inverse_mass_matrix),
         n_steps=3000,
     )
 


### PR DESCRIPTION
In this PR we refactor the kernel and adaptation to be able to run the adaptation in an interactive way. Adaptation is currently exposed as a single function which performs the full adaptation and returns the parameter values:


```python
import aesara.tensor as at
from aesatra.tensor.var import TensorVariable
from aehmc import nuts, window_adaptation

srng = at.random.RandomStream(seed=0)
Y_rv = srng.normal(1, 2)

def logprob_fn(y: TensorVariable):
    logprob = joint_logprob({Y_rv: y})
    return logprob

def kernel_factory(inverse_mass_matrix: TensorVariable):
    return nuts.kernel(
        srng,
        logprob_fn,
        inverse_mass_matrix,
    )

y_vv = Y_rv.clone()
initial_state = nuts.new_state(y_vv, logprob_fn)

state, (step_size, inverse_mass_matrix), updates = window_adaptation.run(
    kernel_factory, initial_state, num_steps=1000
)
```

However, this kind of monolithic process is not suited for instance when the NUTS kernel is part of a Metropolis-within-Gibbs scheme and the value of some values is not updated using NUTS. We should provide instead an *adaptation kernel*, so that an update step would (roughly) look like:

```python
new_state, updates_step = nuts_kernel(*state, step_size, inverse_mass_matrix)
new_adaptation_state, step_size, inverse_mass_matrix, updates_adapt = adapt_kernel(
    adaptation_state, new_state
)
```

This way we should be in a position where we can completely decouple NUTS kernel and the adaptation schemes in [aemcmc](https://github.com/aesara-devs/aemcmc). This PR was partially motivated by https://github.com/aesara-devs/aemcmc/pull/35 and a professional project. Closes #65 