### PR TITLE
Skip trajectory building if the first step diverges

### DIFF
--- a/aehmc/proposals.py
+++ b/aehmc/proposals.py
@@ -85,7 +85,10 @@ def progressive_uniform_sampling(
     state, energy, weight, _ = proposal
     new_state, new_energy, new_weight, _ = new_proposal
 
+    # TODO: Make the `at.isnan` check unnecessary
     p_accept = at.expit(new_weight - weight)
+    p_accept = at.where(at.isnan(p_accept), 0, p_accept)
+
     do_accept = srng.bernoulli(p_accept)
     updated_proposal = maybe_update_proposal(do_accept, proposal, new_proposal)
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # To use:
 #
 #   $ conda env create -f environment.yml  # `mamba` works too for this command
-#   $ conda activate aemcmc-dev
+#   $ conda activate aehmc-dev
 #
 name: aehmc-dev
 channels:

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -71,7 +71,8 @@ def test_static_integration(example):
     "case",
     [
         (0.0000001, False, False),
-        (1000, True, True),
+        (1000, True, False),
+        (1e100, True, False),
     ],
 )
 def test_dynamic_integration(case):
@@ -136,7 +137,7 @@ def test_dynamic_integration(case):
 @pytest.mark.parametrize(
     "step_size, should_diverge, should_turn, expected_doublings",
     [
-        (100000.0, True, True, 1),
+        (100000.0, True, False, 1),
         (0.0000001, False, False, 10),
         (1.0, False, True, 1),
     ],


### PR DESCRIPTION
The NUTS kernel fails for a combination of large step size and large logprob values  (#75). This happens because `AeHMC` will attempt to build the trajectory even if the first step was diverging, and try to subtract two `np.inf` values. In this PR we skip trajectory building if the first transition is divergent.

Closes #75 
