### PR TITLE
Fix schedule length for small number of adaptation steps

### DIFF
--- a/aehmc/window_adaptation.py
+++ b/aehmc/window_adaptation.py
@@ -252,7 +252,7 @@ def build_schedule(
 
     # Give up on mass matrix adaptation when the number of warmup steps is too small.
     if num_steps < 20:
-        schedule += [(0, False)] * (num_steps - 1)
+        schedule += [(0, False)] * num_steps
     else:
         # When the number of warmup steps is smaller that the sum of the provided (or default)
         # window sizes we need to resize the different windows.

--- a/tests/test_adaptation.py
+++ b/tests/test_adaptation.py
@@ -6,7 +6,7 @@ from aehmc import window_adaptation
 @pytest.mark.parametrize(
     "num_steps, expected_schedule",
     [
-        (19, [(0, False)] * 18),  # no mass matrix adaptation
+        (19, [(0, False)] * 19),  # no mass matrix adaptation
         (
             100,
             [(0, False)] * 15 + [(1, False)] * 74 + [(1, True)] + [(0, False)] * 10,
@@ -24,4 +24,5 @@ from aehmc import window_adaptation
 )
 def test_adaptation_schedule(num_steps, expected_schedule):
     adaptation_schedule = window_adaptation.build_schedule(num_steps)
+    assert num_steps == len(adaptation_schedule)
     assert adaptation_schedule == expected_schedule


### PR DESCRIPTION
The `build_schedule` function returns a schedule of length `num_steps` when the number of specified steps is >= 20 and `num_steps-1` otherwise. In this PR we fix the latter case.