### PR TITLE
Update `ShapeFeature` imports

### DIFF
--- a/aehmc/utils.py
+++ b/aehmc/utils.py
@@ -5,7 +5,7 @@ import aesara.tensor as at
 from aesara.graph.basic import Variable, ancestors
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.rewriting.utils import rewrite_graph
-from aesara.tensor.rewriting.basic import ShapeFeature
+from aesara.tensor.rewriting.shape import ShapeFeature
 from aesara.tensor.var import TensorVariable
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,8 @@ dependencies:
   - compilers
   - numpy>=1.18.1
   - scipy>=1.4.0
-  - aesara>=2.8.0
-  - aeppl>=0.0.35
+  - aesara>=2.8.3
+  - aeppl>=0.0.38
   # Intel BLAS
   - mkl
   - mkl-service

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "aesara>=2.8.0",
-        "aeppl>=0.0.35",
+        "aesara>=2.8.3",
+        "aeppl>=0.0.38",
     ],
     tests_require=["pytest"],
     long_description=open("README.md").read() if exists("README.md") else "",


### PR DESCRIPTION
This PR updates the now deprecated `ShapeFeature` imports (i.e. Aesara >= 2.8.3).