### PR TITLE
Fix error in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Example
 
     # Build the transition kernel
     srng = RandomStream(seed=0)
-    kernel = nuts.kernel(srng, logprob_fn)
+    kernel = nuts.new_kernel(srng, logprob_fn)
 
     # Compile a function that updates the chain
     y_vv = Y_rv.clone()


### PR DESCRIPTION
The name of the function to create a NUTS kernel has not been updated when the function's name changed. This fixes it.